### PR TITLE
effect dependency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/dist
 dev.db
 src/tests/fixtures/prisma-client
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     }
   },
   "scripts": {
-    "seed": "rm ./prisma/dev.db && prisma db push && tsx prisma/seed.ts",
-    "test": "pnpm seed && NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "prisma:generate": "mkdir -p src/tests/fixtures/prisma-client && prisma generate",
+    "seed": "rm -f ./prisma/dev.db && prisma db push && tsx prisma/seed.ts",
+    "test": "pnpm prisma:generate && pnpm seed && NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "build": "nanobundle build --external '@prisma/generator-helper' --external 'ts-morph'",
     "prepack": "pnpm build",
     "release": "release-it"
@@ -65,7 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "camelcase": "^8.0.0",
-    "effect": "2.0.0-next.32",
+    "effect": "2.2.2",
     "eslint": "^8.49.0",
     "eslint-plugin-dprint-integration": "^0.3.0",
     "graphql": "^16.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       effect:
-        specifier: 2.0.0-next.32
-        version: 2.0.0-next.32(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/match@0.35.2)(@effect/stm@0.24.0)(@effect/stream@0.36.0)
+        specifier: 2.2.2
+        version: 2.2.2
       eslint:
         specifier: ^8.49.0
         version: 8.49.0
@@ -518,23 +518,11 @@ packages:
     resolution: {integrity: sha512-QCYkLE5Y5Dm5Yax5R3GmW4ZIgTx7W+kSZ7yq5eqQ/mFWa8i4yxbLuu8cudqzdeZtRtTGZKlhDxfFfgVtMywXJg==}
     dev: false
 
-  /@effect/data@0.18.5:
-    resolution: {integrity: sha512-VFPJ0prGq3eF6/eZYKVI/1IC1purdGJXEHJC1ggKynPko03upjtmeCeCsEyMiY12DzVIAuME425JndiFb7m2xw==}
-    dev: true
-
   /@effect/io@0.37.1:
     resolution: {integrity: sha512-Ez3GfcG+gDDfAiBXtSjJpSrPU5Guiyw69LsYkMtIukFwyNwpHWLhYaVgfVbVjoQasil8KiFSQJSd5DbJL6nqPg==}
     dependencies:
       '@effect/data': 0.17.1
     dev: false
-
-  /@effect/io@0.40.1(@effect/data@0.18.5):
-    resolution: {integrity: sha512-OeMK7JonvW/D6Z377cOsuCSHUbsO9ZkmAIDmzQ1Qffx8+h5yUXRm0htmPwKkxtCHZr2QxyZfSBzxSzrGU7asXQ==}
-    peerDependencies:
-      '@effect/data': ^0.18.5
-    dependencies:
-      '@effect/data': 0.18.5
-    dev: true
 
   /@effect/match@0.31.0:
     resolution: {integrity: sha512-QT0HSh19Y6iHAghc51Yt/rYDU9/jhs7O+2kSEQiJqj4xqCLjfJONWsK19xBCNbuV5bt3ZO1NGFqvsWeNR7ZhDg==}
@@ -542,14 +530,6 @@ packages:
       '@effect/data': 0.17.1
       '@effect/schema': 0.32.0
     dev: false
-
-  /@effect/match@0.35.2(@effect/data@0.18.5):
-    resolution: {integrity: sha512-2zZhWIdejX3xqbjormykBveHZTB/DBr/u/XBj5Ln6u2ShbMvoUykgVEscQLN3CsQeHDS14Vvr1DOvH0qeMILZQ==}
-    peerDependencies:
-      '@effect/data': ^0.18.3
-    dependencies:
-      '@effect/data': 0.18.5
-    dev: true
 
   /@effect/schema@0.32.0:
     resolution: {integrity: sha512-4HJK/cFkVPdIjYICy0eRsL7JuuLJ6mE3aJC5rX9OuUIei/qfctFEEX2NaARjtGX7hACBrRcuJCNwiq+54TTjFw==}
@@ -566,32 +546,12 @@ packages:
       '@effect/io': 0.37.1
     dev: false
 
-  /@effect/stm@0.24.0(@effect/data@0.18.5)(@effect/io@0.40.1):
-    resolution: {integrity: sha512-6L4zhy2lvkxn3jMG7dvZ4lKOmxSvaNBpkIT/ZOS6mad+B5/r8G3bKFe0C70aHwpQkxORd9LVmFr/f5MXLKZtfQ==}
-    peerDependencies:
-      '@effect/data': ^0.18.3
-      '@effect/io': ^0.40.0
-    dependencies:
-      '@effect/data': 0.18.5
-      '@effect/io': 0.40.1(@effect/data@0.18.5)
-    dev: true
-
   /@effect/stream@0.33.0:
     resolution: {integrity: sha512-4RjcsLOFc2w6zo243qNMGHDhpIZf3lgPALqvOLt1fvWqIaQdeQ4PF6lfFCTHfzfnRSiW3Hm5K8KDiGwwY/azfA==}
     dependencies:
       '@effect/data': 0.17.1
       '@effect/io': 0.37.1
     dev: false
-
-  /@effect/stream@0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1):
-    resolution: {integrity: sha512-vAMQ3kumsAXAiAwtuzJEOeII2bAB9rNY1NLYOqpgvXVWTUIYQf/wy4QbbcLXLuoMUUi7zS/JDVmC8jbPscfLNg==}
-    peerDependencies:
-      '@effect/data': ^0.18.3
-      '@effect/io': ^0.40.0
-    dependencies:
-      '@effect/data': 0.18.5
-      '@effect/io': 0.40.1(@effect/data@0.18.5)
-    dev: true
 
   /@envelop/core@4.0.1:
     resolution: {integrity: sha512-uBLI7ql3hZopz7vMi9UDAb9HWzKw4STKiqg4QT+lb+tu5ZNaeuJ4fom2rrmgITz38B85QZOhZrGyVrlJXxfDzw==}
@@ -2740,20 +2700,8 @@ packages:
       '@effect/stream': 0.33.0
     dev: false
 
-  /effect@2.0.0-next.32(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/match@0.35.2)(@effect/stm@0.24.0)(@effect/stream@0.36.0):
-    resolution: {integrity: sha512-WSh1x3ajpKcinJrPLdlY+8/SSp2KZUOQywQfefRDWDo0aaLgNRbOFS1onDJdjtC0qDbay2f30UiTH7XtZm8+1A==}
-    peerDependencies:
-      '@effect/data': ^0.18.5
-      '@effect/io': ^0.40.1
-      '@effect/match': ^0.35.2
-      '@effect/stm': ^0.24.0
-      '@effect/stream': ^0.36.0
-    dependencies:
-      '@effect/data': 0.18.5
-      '@effect/io': 0.40.1(@effect/data@0.18.5)
-      '@effect/match': 0.35.2(@effect/data@0.18.5)
-      '@effect/stm': 0.24.0(@effect/data@0.18.5)(@effect/io@0.40.1)
-      '@effect/stream': 0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1)
+  /effect@2.2.2:
+    resolution: {integrity: sha512-hY/37Ssd2Zfn0r09vDe9tSYPVS5HZBbmW4DMBO7OIIvRADgp5cnWfLhY6pVy+Bm5DXV9luFycjDcB1731WGyTA==}
     dev: true
 
   /electron-to-chromium@1.4.520:

--- a/src/field-builder.ts
+++ b/src/field-builder.ts
@@ -19,9 +19,8 @@ function checkAndThrowResultIfFailure<E, A>(
   result: Exit.Exit<E, A>,
   FailErrorConstructor: { new(message: string): unknown } = Error,
 ): asserts result is Exit.Success<E, A> {
-  // Check if result is a failure
   if (Exit.isFailure(result)) {
-    const cause = Cause.unannotate(result.cause);
+    const cause = result.cause;
 
     // TODO: shoud it handle empty/die/interrupt/etc cases?
     if (Cause.isFailType(cause) && (cause.error as unknown) instanceof Error) {
@@ -149,8 +148,8 @@ async function resolveEffectField(
   // Provide layer and context to resolve field effect
   const program = pipe(
     fieldResult as Effect.Effect<never, never, any>,
-    Effect.provideSomeLayer(layer),
-    Effect.provideSomeContext(context),
+    Effect.provide(layer),
+    Effect.provide(context),
   );
 
   // Run effect via runPromiseExit to handle error or success value

--- a/src/tests/integrate-errors.test.ts
+++ b/src/tests/integrate-errors.test.ts
@@ -1,7 +1,7 @@
 import SchemaBuilder from '@pothos/core';
 import ErrorsPlugin from '@pothos/plugin-errors';
 import EffectPlugin from '../index';
-import { Cause, Effect } from 'effect/index';
+import { Cause, Effect } from 'effect';
 import { execute, parse } from 'graphql';
 
 class ForbiddenError extends Error {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "outDir": "./dist"
   },
-  "include": ["src", "src/tests"]
+  "include": ["src", "src/tests", "node_modules/@pothos/plugin-prisma"]
 }


### PR DESCRIPTION
In order to allow new users of pothos and effect to use this plugin while referring to latest documentation, effect dependency must be updated.

changes made:
* gitignore intellij files with .idea/
* update effect dependency
* create `src/tests/fixtures/prisma-client` directory if it doesn't exist (generate will fail on clean system without this)
* `prisma generate` before tests as they are a dependency of integrate-prisma.test.ts.  test fail without this
* fix field-builder.ts file to use modern effect version
* fix [integrate-errors.test.ts to get effect dependencies from 'effect'
* add "node_modules/@pothos/plugin-prisma" to tsconfig.json include so build can reference it
 